### PR TITLE
build from git, add 2.4 deps, default to 2.4.x

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -1,24 +1,24 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
-ARG VERSION=2.3.5
+ARG GIT_HASH=cfee565ebb0a1db07619c9008a9b8b37e21be166
 
 RUN \
     apk add --update \
         alpine-sdk bash python perl protobuf-dev icu-dev \
         libressl-dev curl-dev boost-dev linux-headers \
-        bsd-compat-headers m4 paxmark libexecinfo-dev
+        bsd-compat-headers m4 paxmark libexecinfo-dev unzip nodejs-npm && \
+        npm install -g coffeescript browserify@13.1.0
 
 RUN \
-    wget https://download.rethinkdb.com/dist/rethinkdb-$VERSION.tgz && \
-    gunzip rethinkdb-$VERSION.tgz && \
-    tar xvf rethinkdb-$VERSION.tar && \
-    rm rethinkdb-$VERSION.tar
+    wget https://github.com/rethinkdb/rethinkdb/archive/$GIT_HASH.zip && \
+    unzip $GIT_HASH.zip && \
+    rm $GIT_HASH.zip
 
 
-COPY libressl.patch ./rethinkdb-$VERSION/libressl.patch
+COPY libressl.patch ./rethinkdb-$GIT_HASH/libressl.patch
 
 RUN \
-    cd rethinkdb-$VERSION && \
+    cd rethinkdb-$GIT_HASH && \
     patch -p1 < libressl.patch && \
     ./configure \
         --prefix=/usr \

--- a/Dockerfile.min
+++ b/Dockerfile.min
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.6
 
 RUN \
     apk add --update \

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 ORG?=jlhawn
 PROJ?=rethinkdb
-VERSION?=2.3.5
+DOCKER_TAG?=2.4.0-cfee565
+GIT_HASH?=cfee565ebb0a1db07619c9008a9b8b37e21be166
 
 image:
 
 	# Build the rethinkdb-build image.
-	docker build --build-arg VERSION=$(VERSION) -t rethinkdb-build -f Dockerfile.build .
+	docker build --build-arg GIT_HASH=$(GIT_HASH) -t rethinkdb-build -f Dockerfile.build .
 
 	# Create a container from that image, copy out the built RethinkDB binary
 	# into the local bin directory, and remove the container.
@@ -15,8 +16,8 @@ image:
 	docker rm rethinkdb-build
 
 	# Build the minimal image.
-	docker build -t $(ORG)/$(PROJ):$(VERSION) -f Dockerfile.min .
+	docker build -t $(ORG)/$(PROJ):$(DOCKER_TAG) -f Dockerfile.min .
 
 push:
 
-	docker push $(ORG)/$(PROJ):$(VERSION)
+	docker push $(ORG)/$(PROJ):$(DOCKER_TAG)


### PR DESCRIPTION
Doesn't work yet. Running it gives me:
```
Error loading shared library libcrypto.so.41: No such file or directory (needed by /usr/local/bin/rethinkdb)
Error loading shared library libssl.so.43: No such file or directory (needed by /usr/local/bin/rethinkdb)
```