### PR TITLE
Remove libcurl install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -52,7 +52,7 @@ FROM alpine:latest
 
 RUN \
     apk add --update \
-        ca-certificates libstdc++ libgcc libcurl protobuf libexecinfo
+        ca-certificates libstdc++ libgcc protobuf libexecinfo
 
 COPY --from=builder /usr/local/bin/rethinkdb /usr/local/bin/rethinkdb
 


### PR DESCRIPTION
Succeptible to [CVE-2018-16840](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-16840)